### PR TITLE
add more explicit protobuf namespace for csharp

### DIFF
--- a/api/api.proto
+++ b/api/api.proto
@@ -28,7 +28,7 @@ option java_multiple_files = true;
 option java_outer_classname = "NakamaApi";
 option java_package = "com.heroiclabs.nakama.api";
 
-option csharp_namespace = "Nakama";
+option csharp_namespace = "Nakama.Protobuf";
 
 option objc_class_prefix = "NKPB";
 

--- a/rtapi/realtime.proto
+++ b/rtapi/realtime.proto
@@ -29,7 +29,7 @@ option java_multiple_files = true;
 option java_outer_classname = "NakamaRealtime";
 option java_package = "com.heroiclabs.nakama.rtapi";
 
-option csharp_namespace = "Nakama";
+option csharp_namespace = "Nakama.Protobuf";
 
 option objc_class_prefix = "NKPB";
 


### PR DESCRIPTION
I think we'll want this for two reasons:

(1) So Protobuf serialization classes don't conflict with user-facing classes (e.g., Match)
(2) To make it easier for users to see when they are `using` our dotnet protobuf .dll.