### PR TITLE
Add Apple IAP validation secret override.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3983,10 +3983,11 @@ declare namespace nkruntime {
          *
          * @param userID - User ID.
          * @param receipt - Apple receipt to validate.
+         * @param passwordOverride - Opt. Override the configured Apple Store Validation Password.
          * @returns The result of the validated and stored purchases from the receipt.
          * @throws {TypeError, GoError}
          */
-        purchaseValidateApple(userID: string, receipt: string): ValidatePurchaseResponse
+        purchaseValidateApple(userID: string, receipt: string, passwordOverride?: string): ValidatePurchaseResponse
 
         /**
          * Validate a Google purchase payload.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -932,7 +932,7 @@ type NakamaModule interface {
 	LeaderboardRecordDelete(ctx context.Context, id, ownerID string) error
 	LeaderboardsGetId(ctx context.Context, ids []string) ([]*api.Leaderboard, error)
 
-	PurchaseValidateApple(ctx context.Context, userID, receipt string) (*api.ValidatePurchaseResponse, error)
+	PurchaseValidateApple(ctx context.Context, userID, receipt string, passwordOverride ...string) (*api.ValidatePurchaseResponse, error)
 	PurchaseValidateGoogle(ctx context.Context, userID, receipt string) (*api.ValidatePurchaseResponse, error)
 	PurchaseValidateHuawei(ctx context.Context, userID, signature, inAppPurchaseData string) (*api.ValidatePurchaseResponse, error)
 	PurchasesList(ctx context.Context, userID string, limit int, cursor string) (*api.PurchaseList, error)


### PR DESCRIPTION
Allow PurchaseValidateApple to be called with an optional parameter to override the configured Apple shared password.