### PR TITLE
Fix field name used in MatchMessage type in TypeScript definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 - JavaScript runtime Base64 decode returns ArrayBuffer output.
 - JavaScript runtime Base64 URL decode returns ArrayBuffer output.
 - JavaScript runtime Base16 decode returns ArrayBuffer output.
+- Fix field name used in MatchMessage type in TypeScript definition.
 
 ## [1.24.0] - 2022-08-18
 ### Added

--- a/index.d.ts
+++ b/index.d.ts
@@ -287,7 +287,7 @@ declare namespace nkruntime {
         opCode: number;
         data: ArrayBuffer;
         reliable: boolean;
-        receiveTime: number;
+        receiveTimeMs: number;
     }
 
     /**


### PR DESCRIPTION
Use `receiveTimeMs` instead of `receiveTime` (https://github.com/heroiclabs/nakama/blob/ad1f9c0341ade94368300e859429eba0f5097728/server/runtime_javascript_match_core.go#L417)