### PR TITLE
fix: registerAfter/BeforeValidatePurchaseGoogle defined double times

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2268,7 +2268,7 @@ declare namespace nkruntime {
          * @param fn - The function to execute before ValidatePurchaseGoogle.
          * @throws {TypeError}
          */
-        registerBeforeValidatePurchaseGoogle(fn: BeforeHookFunction<ValidateSubscriptionGoogleRequest>): void;
+        registerBeforeValidateSubscriptionGoogle(fn: BeforeHookFunction<ValidateSubscriptionGoogleRequest>): void;
 
         /**
          * Register after Hook for RPC ValidatePurchaseGoogle function.
@@ -2276,7 +2276,7 @@ declare namespace nkruntime {
          * @param fn - The function to execute after ValidatePurchaseGoogle.
          * @throws {TypeError}
          */
-        registerAfterValidatePurchaseGoogle(fn: AfterHookFunction<ValidateSubscriptionResponse, ValidateSubscriptionGoogleRequest>): void;
+        registerAfterValidateSubscriptionGoogle(fn: AfterHookFunction<ValidateSubscriptionResponse, ValidateSubscriptionGoogleRequest>): void;
 
         /**
          * Register before Hook for RPC ValidatePurchaseHuawei function.

--- a/index.d.ts
+++ b/index.d.ts
@@ -2271,9 +2271,9 @@ declare namespace nkruntime {
         registerBeforeValidateSubscriptionGoogle(fn: BeforeHookFunction<ValidateSubscriptionGoogleRequest>): void;
 
         /**
-         * Register after Hook for RPC ValidatePurchaseGoogle function.
+         * Register after Hook for RPC ValidateSubscriptionGoogle function.
          *
-         * @param fn - The function to execute after ValidatePurchaseGoogle.
+         * @param fn - The function to execute after ValidateSubscriptionGoogle.
          * @throws {TypeError}
          */
         registerAfterValidateSubscriptionGoogle(fn: AfterHookFunction<ValidateSubscriptionResponse, ValidateSubscriptionGoogleRequest>): void;


### PR DESCRIPTION
One of them was a subscription-related function, but the names were the same. I have corrected that part.