### PR TITLE
add defaultValue as second arg for localcacheGet signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5172,10 +5172,11 @@ declare namespace nkruntime {
          * Get local cache data by key.
          *
          * @param key - local cache key.
+         * @param defaultValue - defaultValue if it cannot find.
          * @throws {TypeError, GoError}
          * @returns local cache object.
          */
-        localcacheGet(key: string): any;
+        localcacheGet(key: string, defaultValue?: any): any;
 
         /**
          * Put data to local cache.


### PR DESCRIPTION
Based on the Go runtime code, the function supports 2nd parameter as a default value.

code reference

https://github.com/heroiclabs/nakama/blob/b04438720b4bf2e848c7a98fce1290447f3fbf12/server/runtime_javascript_nakama.go#L8556C1-L8559C4