### PR TITLE
Add named multi Fleet Manager support

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -896,6 +896,9 @@ type Initializer interface {
 	// RegisterFleetManager can be used to register a FleetManager implementation that can be retrieved from the runtime using GetFleetManager().
 	RegisterFleetManager(fleetManagerInit FleetManagerInitializer) error
 
+	// RegisterFleetManagerByName registers a FleetManager implementation under the given name, retrievable using GetFleetManagerByName(). The empty name is the default.
+	RegisterFleetManagerByName(name string, fleetManagerInit FleetManagerInitializer) error
+
 	// RegisterShutdown can be used to register a function that is executed once the server receives a termination signal.
 	// This function only fires if shutdown_grace_sec > 0 and will be terminated early if its execution takes longer than the configured grace seconds.
 	RegisterShutdown(fn func(ctx context.Context, logger Logger, db *sql.DB, nk NakamaModule)) error
@@ -1249,6 +1252,7 @@ type NakamaModule interface {
 
 	GetSatori() Satori
 	GetFleetManager() FleetManager
+	GetFleetManagerByName(name string) FleetManager
 }
 
 /*


### PR DESCRIPTION
Add `RegisterFleetManagerByName` and `GetFleetManagerByName` to allow for registering multiple fleet managers and get them by key